### PR TITLE
dev.socrata.com#798: The way we had MathJAX configured was erasing unescaped double dollar signs

### DIFF
--- a/default.html
+++ b/default.html
@@ -20,7 +20,7 @@
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         tex2jax: {
-          inlineMath: [['$','$'], ['\\(','\\)']],
+          inlineMath: [['\\(','\\)']],
           processEscapes: true
         }
       });


### PR DESCRIPTION
This updates our MathJAX configuration to only use `\\(` and `\\)` as delimiters, which are much less common.