### PR TITLE
Updating Chromeless template

### DIFF
--- a/chromeless.html
+++ b/chromeless.html
@@ -77,7 +77,6 @@
 
   <body class="{{ site.subsite }} {{ page.bodyclass }} {{ page.name | split: "." | first }}">
     <!-- Path: "{{page.path }}" -->
-    <!-- URL: "{{page.url contains "/consumers/" }}" -->
     <div class="container-fluid content">
       {{content}}
     </div> <!-- /container -->


### PR DESCRIPTION
Our new AEP docs on dev.socrata.com use the chromeless template. In fact, they are the only ones on the site that use the chromeless template. When the build tries to pull in this template, liquid gets cranky about a commented out line. This removes that line so that we can fix the build and get the changes shipped for AOIC.